### PR TITLE
requests 2.7.0 is not compatible with pyrax. 2.3.0 works in prod fr

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ name = 'insight_reloaded'
 version = read_relative_file('VERSION').strip()
 readme = read_relative_file('README')
 requirements = ['setuptools', 'tornado', 'tornado-redis',
-                'requests', 'redis', 'raven<5.0.0', 'boto',
+                'requests<2.4.0', 'redis', 'raven<5.0.0', 'boto',
                 'pyrax<1.8.0']
 entry_points = {'console_scripts':
                 ['insight_api = insight_reloaded.api:main',


### PR DESCRIPTION
that's partly why previews don't work on novpostme
